### PR TITLE
Add regtempt2folder parameter to struc_preproc.sh part 3 in non clust…

### DIFF
--- a/BRC_structural_pipeline/struc_preproc.sh
+++ b/BRC_structural_pipeline/struc_preproc.sh
@@ -439,6 +439,7 @@ else
                       --dosubseg=${do_Sub_seg} \
                       --tempt1folder=${TempT1Folder} \
                       --tempt2folder=${TempT2Folder} \
+                      --regtempt2folder=${regTempT2Folder} \
                       --rawt2folder=${rawT2Folder} \
                       --dotissueseg=${do_tissue_seg} \
                       --dodefacing=${do_defacing} \


### PR DESCRIPTION
In non-cluster mode the regTempT2Folder parameter is missing from preproc script part 3 causing error when T2 data is supplied
